### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 A collection of Model Context Protocol (MCP) servers aimed at software developers who use LLMs for development assistance. While many developers prefer Cline for its direct VSCode integration, it uses a pay-per-use API that becomes costly with heavy usage. This project leverages the flat-rate Claude Pro subscription by connecting Claude Desktop application with custom MCP servers, providing comparable development assistance capabilities without the variable costs.
 
+<a href="https://glama.ai/mcp/servers/@ukkz/claude-ts-mcps">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@ukkz/claude-ts-mcps/badge" alt="Claude TypeScript Servers MCP server" />
+</a>
+
 日本語による解説記事: [Cline任せでコード書いてたらAPIクレジットが爆散したのでClaude Desktop + MCPをいい感じにしてサブスクだけで無双する](https://zenn.dev/ukkz/articles/c8726063edd2cd)
 
 ## Overview


### PR DESCRIPTION
This PR adds a badge for the [Claude TypeScript MCP Servers](https://glama.ai/mcp/servers/@ukkz/claude-ts-mcps) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@ukkz/claude-ts-mcps">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@ukkz/claude-ts-mcps/badge" alt="Claude TypeScript Servers MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.